### PR TITLE
when re-import, pages/episodes are duplicated.

### DIFF
--- a/app/fumifumi/fumifumi/magazine/import.rb
+++ b/app/fumifumi/fumifumi/magazine/import.rb
@@ -6,8 +6,9 @@ module Fumifumi
         @magazine = magazine
       end
 
-      def call
+      def call # rubocop:disable Metrics/MethodLength
         update_magazine do |magazine|
+          magazine.reset!
           magazine.update! title: book.title
           toc = {}
 

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -2,4 +2,5 @@
 class Episode < ApplicationRecord
   belongs_to :magazine
   belongs_to :page
+  scope :sorted, -> { includes(:page).order('pages.no') }
 end

--- a/app/models/magazine.rb
+++ b/app/models/magazine.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Magazine < ApplicationRecord
   has_many :pages, -> { order(:no) }
-  has_many :episodes, -> { includes(:page).order('pages.no') }
+  has_many :episodes
 
   has_attached_file :source
   validates_attachment :source,

--- a/app/models/magazine.rb
+++ b/app/models/magazine.rb
@@ -11,4 +11,9 @@ class Magazine < ApplicationRecord
   def cover
     pages.first
   end
+
+  def reset!
+    pages.delete_all
+    episodes.delete_all
+  end
 end

--- a/spec/fumifumi/fumifumi/magazine/import_spec.rb
+++ b/spec/fumifumi/fumifumi/magazine/import_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe Fumifumi::Magazine::Import do
         *subject.pages[1..4].to_a
       )
     end
+
+    context 'import again' do
+      subject { magazine.reload }
+      it do
+        3.times { Fumifumi::Magazine::Import.new(magazine).call }
+        expect(subject.pages.size).to eq(5)
+      end
+    end
   end
 
   xcontext 'real epub' do

--- a/spec/models/episode_spec.rb
+++ b/spec/models/episode_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+RSpec.describe Episode do
+  describe 'sorted scope' do
+    let(:magazine) { create(:magazine) }
+    let!(:page2) { create(:page, no: 2, magazine: magazine) }
+    let!(:page1) { create(:page, no: 1, magazine: magazine) }
+    let!(:episode2) { create(:episode, page: page2, magazine: magazine) }
+    let!(:episode1) { create(:episode, page: page1, magazine: magazine) }
+
+    subject { magazine.episodes.sorted }
+    it { expect(subject).to eq([episode1, episode2]) }
+  end
+end

--- a/spec/models/magazine_spec.rb
+++ b/spec/models/magazine_spec.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
 RSpec.describe Magazine, type: :model do
+  describe '#reset!' do
+    let(:magazine) { create(:magazine) }
+    let!(:pages) { create_list(:page, 3, magazine: magazine) }
+    let!(:episodes) { create_list(:episode, 2, page: pages.first, magazine: magazine) }
+
+    subject { magazine }
+    before { magazine.reset! }
+    it do
+      expect(subject.pages).to be_empty
+      expect(subject.episodes).to be_empty
+    end
+  end
+
   describe '#pages' do
     let(:cover) do
       build(:page, no: 1)
@@ -19,16 +32,5 @@ RSpec.describe Magazine, type: :model do
       expect(subject.pages.map(&:no)).to eq([1, 2, 3])
       expect(subject.cover).to eq(cover)
     end
-  end
-
-  describe '#episodes' do
-    let(:magazine) { create(:magazine) }
-    let!(:page2) { create(:page, no: 2, magazine: magazine) }
-    let!(:page1) { create(:page, no: 1, magazine: magazine) }
-    let!(:episode2) { create(:episode, page: page2, magazine: magazine) }
-    let!(:episode1) { create(:episode, page: page1, magazine: magazine) }
-
-    subject { magazine.episodes }
-    it { expect(subject).to eq([episode1, episode2]) }
   end
 end


### PR DESCRIPTION
To avoid this, remove old pages/episodes before import process.