### PR TITLE
Fix file watch method

### DIFF
--- a/.postcssrc.json
+++ b/.postcssrc.json
@@ -21,5 +21,6 @@
       "last 2 iOS versions",
       "last 2 ChromeAndroid versions"
     ]
-  }
+  },
+  "poll": true
 }

--- a/README.md
+++ b/README.md
@@ -10,18 +10,13 @@ fumi\*fumi is web app to manage ebooks, especially comic magazine. It imports ma
 ```sh
 docker-compose build
 
-# prepare frontend asset
+# prepare dependencies
 docker-compose run js yarn install
-docker-compose run js yarn build:js
-docker-compose run js yarn build:css
-
-# prepare rails env
 docker-compose run app bash -i -c bundle
 docker-compose run app bash -i -c './bin/rails db:setup'
 
-# launch app/job container
-docker-compose up app
-docker-compose up job
+# launch app/job/js container
+dockre-compose up app job js
 ```
 
 ### Deployment

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -49,7 +49,7 @@ steps:
         cd /codefresh/volume/fumifumi
         bundle install --with test
         sleep 20
-        bundle exec rake db:setup
+        RAILS_ENV=test bundle exec rake db:setup
         bundle exec haml-lint
         bundle exec rubocop
         bundle exec rspec

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,4 +52,6 @@ Rails.application.configure do
   # Use plain old file wacher(polling), because event base file wathers
   # doesn't work at network mounted disk(i.e. docker-machine)
   config.file_watcher = ActiveSupport::FileUpdateChecker
+
+  config.web_console.whitelisted_ips = %w( 0.0.0.0/0 ::/0 )
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  # Use an evented file watcher to asynchronously detect changes in source code,
-  # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  # Use plain old file wacher(polling), because event base file wathers
+  # doesn't work at network mounted disk(i.e. docker-machine)
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -53,5 +53,5 @@ Rails.application.configure do
   # doesn't work at network mounted disk(i.e. docker-machine)
   config.file_watcher = ActiveSupport::FileUpdateChecker
 
-  config.web_console.whitelisted_ips = %w( 0.0.0.0/0 ::/0 )
+  config.web_console.whitelisted_ips = %w(0.0.0.0/0 ::/0)
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       dockerfile: Dockerfile.js
     volumes:
       - .:/fumifumi
+    command: yarn start
   db:
     image: mysql:5.7
     volumes:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
+    "start": "yarn watch:css & yarn watch:js",
     "build:css": "postcss -c .postcssrc.json -l",
     "build:js": "NODE_ENV=test webpack",
     "build:js:production": "NODE_ENV=production webpack --bail",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "build:css": "postcss -c .postcssrc.json",
+    "build:css": "postcss -c .postcssrc.json -l",
     "build:js": "NODE_ENV=test webpack",
     "build:js:production": "NODE_ENV=production webpack --bail",
     "lint": "eslint --ext .jsx --ext .js front/src front/test",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint --ext .jsx --ext .js front/src front/test",
     "lint:fix": "eslint --ext .jsx --ext .js front/src front/test --fix",
     "typecheck": "flow check",
-    "watch:js": "webpack -w",
+    "watch:js": "NODE_ENV=test webpack -w",
     "watch:css": "postcss -w -c .postcssrc.json",
     "test": "NODE_ENV=test NODE_PATH=front/src ava"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,5 +27,8 @@ module.exports = {
       "node_modules"
     ],
     extensions: ['.js', '.jsx']
+  },
+  watchOptions: {
+    poll: true
   }
 };


### PR DESCRIPTION
see #44.

At docker-machine environment, file change event doesn't fire. So we should use plain old polling method.
