### PR TITLE
Move /api to /api/web

### DIFF
--- a/config/docker/Dockerfile.js
+++ b/config/docker/Dockerfile.js
@@ -1,4 +1,4 @@
-FROM kkarczmarczyk/node-yarn:7.2-slim
+FROM kkarczmarczyk/node-yarn:7.4-slim
 
 RUN apt update
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,6 @@ require 'sidekiq/web'
 Rails.application.routes.draw do
   get '/' => redirect('/magazines')
 
-  resources :magazines, only: %i(create show), constraints: { id: /\d+/ }
   namespace :magazines do
     resources :dashboard, only: %i(index destroy)
     resources :import, only: %i(create update)
@@ -12,7 +11,7 @@ Rails.application.routes.draw do
 
   scope :api do
     scope :web do
-      resources :magazines, only: %i(index)
+      resources :magazines, only: %i(create index), constraints: { id: /\d+/ }
       resources :episodes, only: %i(show), constraints: { id: /\d+/ }
       namespace :episodes do
         resources :author, only: %i(index)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,11 +11,13 @@ Rails.application.routes.draw do
   end
 
   scope :api do
-    resources :magazines, only: %i(index)
-    resources :episodes, only: %i(show), constraints: { id: /\d+/ }
-    namespace :episodes do
-      resources :author, only: %i(index)
-      resources :magazine, only: %i(show)
+    scope :web do
+      resources :magazines, only: %i(index)
+      resources :episodes, only: %i(show), constraints: { id: /\d+/ }
+      namespace :episodes do
+        resources :author, only: %i(index)
+        resources :magazine, only: %i(show)
+      end
     end
   end
 

--- a/front/src/api/episode/author.js
+++ b/front/src/api/episode/author.js
@@ -1,5 +1,5 @@
 import {get} from "axios";
 
 export default function (name) {
-    return get(`/api/episodes/author?name=${name}`);
+    return get(`/api/web/episodes/author?name=${name}`);
 }

--- a/front/src/api/episode/fetch.js
+++ b/front/src/api/episode/fetch.js
@@ -1,5 +1,5 @@
 import {get} from "axios";
 
 export default function (id) {
-    return get(`/api/episodes/${id}`);
+    return get(`/api/web/episodes/${id}`);
 }

--- a/front/src/api/episode/magazine.js
+++ b/front/src/api/episode/magazine.js
@@ -1,5 +1,5 @@
 import {get} from "axios";
 
 export default function (id) {
-    return get(`/api/episodes/magazine/${id}`);
+    return get(`/api/web/episodes/magazine/${id}`);
 }

--- a/front/src/api/magazine/fetch.js
+++ b/front/src/api/magazine/fetch.js
@@ -1,5 +1,5 @@
 import {get} from "axios";
 
 export default function (page = 1) {
-    return get(`/api/magazines?page=${page}`);
+    return get(`/api/web/magazines?page=${page}`);
 }

--- a/front/src/api/magazine/upload.js
+++ b/front/src/api/magazine/upload.js
@@ -8,5 +8,5 @@ export default function (file) {
 
     data.append("attachment", file);
 
-    return post("/magazines", data, config);
+    return post("/api/web/magazines", data, config);
 }


### PR DESCRIPTION
To add other API(e.g. API for cli agent), move current api to sub category.

Current API is aim to be used by Web/JavaScript Client, so I named it as "Web API".